### PR TITLE
18796: Adjust CI/CD to use slack notification action

### DIFF
--- a/docker/setup/build-src/curlTests.sh
+++ b/docker/setup/build-src/curlTests.sh
@@ -66,7 +66,7 @@ do
   curlResults[$collectionName]=$?
   resultLabel=$(resolveLabel ${curlResults[$collectionName]})
   echo "<tr><td><a href=\"./$page\">$f</a></td>
-    <td>$resultLabel</td></tr>" >> /build/resultLinks.html
+    <td>${resultLabel}</td></tr>" >> /build/resultLinks.html
 done
 
 cat /build/newmanTestResultsHeader.html /build/resultLinks.html /build/newmanTestResultsFooter.html \
@@ -85,7 +85,7 @@ done
 export CURRENT_JOB_BUILD_STATUS=${curlReturnCode}
 
 echo ""
-if [[ ${curlReturnCode} == 0 ]]; then
+if [[ ${CURRENT_JOB_BUILD_STATUS} == 0 ]]; then
   echo "  >>> Curl tests executed successfully <<<"
 else
   echo "  >>> Curl tests failed <<<" >&2
@@ -98,13 +98,16 @@ echo ""
 # Copying gradle report
 cp -R ${reportFolder}/* /custom/output/reports/html/
 
+# Track job results
+trackJob ${CURRENT_JOB_BUILD_STATUS} /custom/output
+
 # Do we want to export the resulting reports to google storage?
-if [[ ! -z "${EXPORT_REPORTS}" && $EXPORT_REPORTS ]]; then
+if [[ "${EXPORT_REPORTS}" == "true" ]]; then
   . /build/${DOT_CICD_PERSIST}/storage.sh
   ignoring_return_value=$?
 fi
 
-if [[ ${curlReturnCode} == 0 ]]; then
+if [[ ${CURRENT_JOB_BUILD_STATUS} == 0 ]]; then
   exit 0
 else
   exit 1

--- a/docker/setup/build-src/github/storage.sh
+++ b/docker/setup/build-src/github/storage.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 export outputFolder="/custom/output"
+export reportsIndexURL="${BASE_STORAGE_URL}/${STORAGE_JOB_BRANCH_FOLDER}/reports/html/index.html"
 
 . /build/printBuildInfo.sh
 

--- a/docker/setup/build-src/githubStatus.sh
+++ b/docker/setup/build-src/githubStatus.sh
@@ -2,8 +2,7 @@
 
 GITHUB_STATUS="failure"
 GITHUB_DESCRIPTION="Tests FAILED"
-if [ ${CURRENT_JOB_BUILD_STATUS} == 0 ]
-then
+if [[ ${CURRENT_JOB_BUILD_STATUS} == 0 ]]; then
   GITHUB_STATUS="success"
   GITHUB_DESCRIPTION="Tests executed SUCCESSFULLY"
 fi
@@ -13,10 +12,7 @@ fi
 # https://storage.googleapis.com/cicd-246518-tests/branch-name/integration/mysql/logs/dotcms.log
 # https://storage.googleapis.com/cicd-246518-tests/branch-name/unit/reports/html/index.html
 # https://storage.googleapis.com/cicd-246518-tests/branch-name/unit/logs/dotcms.log
-if [ "$PULL_REQUEST" != "false" ];
-then
-  reportsIndexURL="${BASE_STORAGE_URL}/${STORAGE_JOB_BRANCH_FOLDER}/reports/html/index.html"
-
+if [ "$PULL_REQUEST" != "false" ]; then
   statusesLabel="Unknown"
   if [[ "${DOT_CICD_CLOUD_PROVIDER}" == "travis" ]]; then
     statusesLabel="Travis CI"
@@ -35,16 +31,16 @@ then
 #  logURL="${BASE_STORAGE_URL}/${STORAGE_JOB_BRANCH_FOLDER}/logs/dotcms.log"
 
 #  echo ""
-#  echo "================================================================================"
-#  echo "================================================================================"
+#  echo "=================================================================================="
+#  echo "=================================================================================="
 #  echo "  >>>   Storage folder for job: [${STORAGE_JOB_BRANCH_FOLDER}]"
 #  echo "  >>>   Reports URL for job: [${reportsIndexURL}]"
 #  echo "  >>>   Log URL for job: [${logURL}]"
 #  echo "  >>>   GITHUB pull request: [https://github.com/dotCMS/core/pull/${PULL_REQUEST}]"
 #  echo "  >>>   Job build status: ${CURRENT_JOB_BUILD_STATUS}"
 #  echo "  >>>   GITHUB user: ${GITHUB_USER}/${GITHUB_USER_TOKEN}"
-#  echo "================================================================================"
-#  echo "================================================================================"
+#  echo "=================================================================================="
+#  echo "=================================================================================="
 #  echo ""
 
   jsonBaseValue="https://api.github.com/repos/dotCMS/core/statuses/"

--- a/docker/setup/build-src/integrationTests.sh
+++ b/docker/setup/build-src/integrationTests.sh
@@ -52,11 +52,10 @@ cd /build/src/core/dotCMS \
   && ./gradlew integrationTest ${GRADLE_PARAMS}
 
 # Required code, without it gradle will exit 1 killing the docker container
-gradlewReturnCode=$?
-export CURRENT_JOB_BUILD_STATUS=${gradlewReturnCode}
+export CURRENT_JOB_BUILD_STATUS=$?
 
 echo ""
-if [[ ${gradlewReturnCode} == 0 ]]; then
+if [[ ${gradlewRCURRENT_JOB_BUILD_STATUSeturnCode} == 0 ]]; then
   echo "  >>> Integration tests executed successfully <<<"
 else
   echo "  >>> Integration tests failed <<<" >&2
@@ -69,15 +68,16 @@ echo ""
 # Copying gradle report
 cp -R /build/src/core/dotCMS/build/reports/tests/integrationTest/* /custom/output/reports/html/
 
+# Track job results
+trackJob ${CURRENT_JOB_BUILD_STATUS} /custom/output
+
 # Do we want to export the resulting reports to google storage?
-if [[ ! -z "${EXPORT_REPORTS}" ]]; then
-  if [[ $EXPORT_REPORTS ]]; then
-    . /build/${DOT_CICD_PERSIST}/storage.sh
-    ignoring_return_value=$?
-  fi
+if [[ "${EXPORT_REPORTS}" == "true" ]]; then
+  . /build/${DOT_CICD_PERSIST}/storage.sh
+  ignoring_return_value=$?
 fi
 
-if [[ ${gradlewReturnCode} == 0 ]]; then
+if [[ ${CURRENT_JOB_BUILD_STATUS} == 0 ]]; then
   exit 0
 else
   exit 1

--- a/docker/setup/build-src/setVars.sh
+++ b/docker/setup/build-src/setVars.sh
@@ -18,15 +18,14 @@ fi
 . /build/common.sh
 
 commitPath="$(resolveTestPath ${BUILD_HASH})"
-branchPath="$(resolveTestPath ${BUILD_ID})"
 
 if [[ "${DOT_CICD_PERSIST}" == "google" ]]; then
   export STORAGE_JOB_COMMIT_FOLDER="cicd-246518-tests/${commitPath}"
-  export STORAGE_JOB_BRANCH_FOLDER="cicd-246518-tests/${branchPath}"
+  export STORAGE_JOB_BRANCH_FOLDER="cicd-246518-tests/$(resolveTestPath ${BUILD_ID})"
   export BASE_STORAGE_URL="https://storage.googleapis.com"
 elif [[ "${DOT_CICD_PERSIST}" == "github" ]]; then
   . /build/github/githubCommon.sh 
   export STORAGE_JOB_COMMIT_FOLDER="${commitPath}"
-  export STORAGE_JOB_BRANCH_FOLDER="${branchPath}"
+  export STORAGE_JOB_BRANCH_FOLDER="$(resolveTestPath current)"
   export BASE_STORAGE_URL=${GITHUB_TEST_RESULTS_BROWSE_URL}
 fi

--- a/docker/setup/build-src/unitTests.sh
+++ b/docker/setup/build-src/unitTests.sh
@@ -17,11 +17,10 @@ cd /build/src/core/dotCMS \
   && ./gradlew test ${EXTRA_PARAMS}
 
 # Required code, without it gradle will exit 1 killing the docker container
-gradlewReturnCode=$?
-export CURRENT_JOB_BUILD_STATUS=${gradlewReturnCode}
+export CURRENT_JOB_BUILD_STATUS=$?
 
 echo ""
-if [[ ${gradlewReturnCode} == 0 ]]; then
+if [[ ${CURRENT_JOB_BUILD_STATUS} == 0 ]]; then
   echo "  >>> Unit tests executed successfully <<<"
 else
   echo "  >>> Unit tests failed <<<" >&2
@@ -34,13 +33,16 @@ echo ""
 # Copying gradle report
 cp -R /build/src/core/dotCMS/build/test-results/unit-tests/html/ /custom/output/reports/
 
+# Track job results
+trackJob ${CURRENT_JOB_BUILD_STATUS} /custom/output
+
 # Do we want to export the resulting reports to google storage?
-if [[ ! -z "${EXPORT_REPORTS}" && $EXPORT_REPORTS ]]; then
+if [[ "${EXPORT_REPORTS}" == "true" ]]; then
   . /build/${DOT_CICD_PERSIST}/storage.sh
   ignoring_return_value=$?
 fi
 
-if [[ ${gradlewReturnCode} == 0 ]]; then
+if [[ ${CURRENT_JOB_BUILD_STATUS} == 0 ]]; then
   exit 0
 else
   exit 1

--- a/seed/install-dot-cicd.sh
+++ b/seed/install-dot-cicd.sh
@@ -5,6 +5,10 @@
 : ${DOT_CICD_BRANCH:=""} && export DOT_CICD_BRANCH
 : ${DOT_CICD_LIB:="${DOT_CICD_PATH}/library"} && export DOT_CICD_LIB
 
+if [ "${DOT_CICD_BRANCH}" -eq "master" ]; then
+  export DOT_CICD_BRANCH=
+fi
+
 echo "#############"
 echo "dot-cicd vars"
 echo "#############"
@@ -33,6 +37,9 @@ gitCloneAndCheckout () {
     exit 1
   fi
 
+  git config --global user.email "dotcmsbuild@dotcms.com"
+  git config --global user.name "dotcmsbuild"
+  git config --global pull.rebase false
   echo "Cloning CI/CD repo from ${DOT_CICD_REPO} to ${DOT_CICD_LIB}"
   git clone ${DOT_CICD_REPO} ${DOT_CICD_LIB}
 
@@ -41,8 +48,9 @@ gitCloneAndCheckout () {
     exit 1
   fi
 
-  if [ ! -z "${DOT_CICD_BRANCH}" ]; then
+  if [ -n "${DOT_CICD_BRANCH}" ]; then
     cd ${DOT_CICD_LIB}
+    git fetch --all
     echo "Checking out branch ${DOT_CICD_BRANCH}"
     git checkout -b ${DOT_CICD_BRANCH}
     if [ $? -ne 0 ]; then


### PR DESCRIPTION
CI/CD needs to store some job results data in the test-results repo so it ca be seen by the action.
Also adding support for creating a branch at 'test-results' repo instead of using master.