### PR TITLE
19969 release automation pending steps

### DIFF
--- a/docker/release/build-src/entrypoint.sh
+++ b/docker/release/build-src/entrypoint.sh
@@ -20,11 +20,11 @@ echo "Debug: ${debug}"
 echo "EE RSA: ${ee_rsa}"
 
 runScript prepareGit ${ee_rsa}
-#runScript getSource ${build_id}
-#runScript setVars
-#runScript generateAndUploadJars ${build_id} ${ee_build_id} ${repo_username} ${repo_password} ${github_sha} ${is_release}
-#runScript buildDistro
-#runScript generateJavadoc
-#runScript pushToStaticBucket all
+runScript getSource ${build_id}
+runScript setVars
+runScript generateAndUploadJars ${build_id} ${ee_build_id} ${repo_username} ${repo_password} ${github_sha} ${is_release}
+runScript buildDistro
+runScript generateJavadoc
+runScript pushToStaticBucket all
 runScript updateOsgiVersion ${github_user_token}
 runScript publishGithubReleases ${is_release} ${ee_build_id} ${ee_rsa}

--- a/docker/release/build-src/entrypoint.sh
+++ b/docker/release/build-src/entrypoint.sh
@@ -19,12 +19,12 @@ echo "Docker password: ${docker_password}"
 echo "Debug: ${debug}"
 echo "EE RSA: ${ee_rsa}"
 
-runScript prepareGit
-runScript getSource ${build_id}
-runScript setVars
-runScript generateAndUploadJars ${build_id} ${ee_build_id} ${repo_username} ${repo_password} ${github_sha} ${is_release}
-runScript buildDistro
-runScript generateJavadoc
-runScript pushToStaticBucket all
-runScript updateOsgiVersion ${github_user_token}
+#runScript prepareGit
+#runScript getSource ${build_id}
+#runScript setVars
+#runScript generateAndUploadJars ${build_id} ${ee_build_id} ${repo_username} ${repo_password} ${github_sha} ${is_release}
+#runScript buildDistro
+#runScript generateJavadoc
+#runScript pushToStaticBucket all
+#runScript updateOsgiVersion ${github_user_token}
 runScript publishGithubReleases ${is_release} ${ee_build_id} ${ee_rsa}

--- a/docker/release/build-src/entrypoint.sh
+++ b/docker/release/build-src/entrypoint.sh
@@ -17,6 +17,7 @@ echo "AWS Secret Access Key: ${aws_secret_access_key}"
 echo "Docker username: ${docker_username}"
 echo "Docker password: ${docker_password}"
 echo "Debug: ${debug}"
+echo "EE RSA: ${ee_rsa}"
 
 runScript prepareGit
 runScript getSource ${build_id}
@@ -26,3 +27,4 @@ runScript buildDistro
 runScript generateJavadoc
 runScript pushToStaticBucket all
 runScript updateOsgiVersion ${github_user_token}
+runScript publishGithubReleases ${is_release} ${ee_build_id} ${ee_rsa}

--- a/docker/release/build-src/entrypoint.sh
+++ b/docker/release/build-src/entrypoint.sh
@@ -19,7 +19,7 @@ echo "Docker password: ${docker_password}"
 echo "Debug: ${debug}"
 echo "EE RSA: ${ee_rsa}"
 
-#runScript prepareGit
+runScript prepareGit ${ee_rsa}
 #runScript getSource ${build_id}
 #runScript setVars
 #runScript generateAndUploadJars ${build_id} ${ee_build_id} ${repo_username} ${repo_password} ${github_sha} ${is_release}

--- a/docker/release/build-src/entrypoint.sh
+++ b/docker/release/build-src/entrypoint.sh
@@ -26,5 +26,5 @@ runScript prepareGit ${ee_rsa}
 #runScript buildDistro
 #runScript generateJavadoc
 #runScript pushToStaticBucket all
-#runScript updateOsgiVersion ${github_user_token}
+runScript updateOsgiVersion ${github_user_token}
 runScript publishGithubReleases ${is_release} ${ee_build_id} ${ee_rsa}

--- a/docker/release/build-src/prepareGit.sh
+++ b/docker/release/build-src/prepareGit.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
 ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
+echo "${ee_rsa}" > ~/.ssh/id_rsa
+chmod 600 ~/.ssh/id_rsa
 ls -las ~/.ssh
 
 git config --global user.email "dotcmsbuild@dotcms.com"

--- a/docker/release/build-src/publishGithubReleases.sh
+++ b/docker/release/build-src/publishGithubReleases.sh
@@ -23,10 +23,10 @@ echo 'Getting submodules'
 git submodule update --init --recursive
 git clean -f -d && git pull
 
-cd core/src/main/enterprise
+cd core/dotCMS/src/main/enterprise
 git checkout ${RELEASE_BRANCH_NAME}
 git commit --allow-empty -m "Publish Release"
-git push origin ${RELEASE_BRANCH_NAME} 
+git push origin ${RELEASE_BRANCH_NAME}
 
 #git checkout ${RELEASE_BRANCH_NAME}
 #git fetch --all

--- a/docker/release/build-src/publishGithubReleases.sh
+++ b/docker/release/build-src/publishGithubReleases.sh
@@ -57,10 +57,10 @@ git push origin ${RELEASE_BRANCH_NAME}
 cd ../dot-cicd
 
 echo 'Releasing on docker'
-git clone git@github.com:dotCMS/docker.git docker
-pushd docker
+git clone git@github.com:dotCMS/docker.git docker-repo
+pushd docker-repo
 git clean -f -d && git pull
 git checkout ${RELEASE_BRANCH_NAME}
 git commit --allow-empty -m "Publish Release"
 git push origin ${RELEASE_BRANCH_NAME}
-cd ../docker
+cd ../docker-repo

--- a/docker/release/build-src/publishGithubReleases.sh
+++ b/docker/release/build-src/publishGithubReleases.sh
@@ -47,7 +47,20 @@ git commit --allow-empty -m "Publish Release"
 git push origin ${RELEASE_BRANCH_NAME}
 cd ../plugin-seeds
 
+echo 'Releasing on dot-cicd'
+git clone git@github.com:dotCMS/dot-cicd.git dot-cicd
+pushd dot-cicd
+git clean -f -d && git pull
+git checkout ${RELEASE_BRANCH_NAME}
+git commit --allow-empty -m "Publish Release"
+git push origin ${RELEASE_BRANCH_NAME}
+cd ../dot-cicd
 
-
-
-#cd ../core
+echo 'Releasing on docker'
+git clone git@github.com:dotCMS/docker.git docker
+pushd docker
+git clean -f -d && git pull
+git checkout ${RELEASE_BRANCH_NAME}
+git commit --allow-empty -m "Publish Release"
+git push origin ${RELEASE_BRANCH_NAME}
+cd ../docker

--- a/docker/release/build-src/publishGithubReleases.sh
+++ b/docker/release/build-src/publishGithubReleases.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+is_release=$1
+ee_build_id=$2
+ee_rsa=$3
+
+if [[ ${is_release} != true ]]; then
+  echo "Not releasing on GitHub on different repos"
+  exit 1;
+fi
+
+echo
+echo '######################################################################'
+echo 'Releasing on enterprise'
+echo '######################################################################'
+
+mkdir -p ~/.ssh
+ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
+echo "${ee_rsa}" > ~/.ssh/id_rsa
+chmod 600 ~/.ssh/id_rsa
+ls -las ~/.ssh
+git config --global user.email "dotcmsbuild@dotcms.com"
+git config --global user.name "dotcmsbuild"
+git config --global pull.rebase false
+
+git clone git@github.com:dotCMS/enterprise.git
+cd enterprise
+git checkout ${ee_build_id}
+git fetch --all
+git commit --allow-empty -m "Publish Release"
+
+cd ../core

--- a/docker/release/build-src/publishGithubReleases.sh
+++ b/docker/release/build-src/publishGithubReleases.sh
@@ -9,7 +9,7 @@ if [[ ${is_release} != true ]]; then
 fi
 
 RELEASE_PREFIX="release-"
-RELEASE_BRANCH_NAME=${ee_rsa/v/$RELEASE_PREFIX}
+RELEASE_BRANCH_NAME=${ee_build_id/v/$RELEASE_PREFIX}
 
 echo
 echo '######################################################################'
@@ -17,19 +17,14 @@ echo 'Releasing on enterprise'
 echo "RELEASE_BRANCH_NAME: " + ${RELEASE_BRANCH_NAME}
 echo '######################################################################'
 
-mkdir -p ~/.ssh
-ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
-echo ${ee_rsa} > ~/.ssh/id_rsa
-chmod 600 ~/.ssh/id_rsa
-ls -las ~/.ssh
-git config --global user.email "dotcmsbuild@dotcms.com"
-git config --global user.name "dotcmsbuild"
-git config --global pull.rebase false
+git clone https://github.com/dotCMS/core.git core
+pushd core
+echo 'Getting submodules'
+git submodule update --init --recursive
+git clean -f -d && git pull
 
-git clone git@github.com:dotCMS/enterprise.git
-cd enterprise
-git checkout ${RELEASE_BRANCH_NAME}
-git fetch --all
-git commit --allow-empty -m "Publish Release"
+#git checkout ${RELEASE_BRANCH_NAME}
+#git fetch --all
+#git commit --allow-empty -m "Publish Release"
 
 cd ../core

--- a/docker/release/build-src/publishGithubReleases.sh
+++ b/docker/release/build-src/publishGithubReleases.sh
@@ -11,56 +11,56 @@ fi
 RELEASE_PREFIX="release-"
 RELEASE_BRANCH_NAME=${ee_build_id/v/$RELEASE_PREFIX}
 
-#echo
-#echo '######################################################################'
-#echo "RELEASE_BRANCH_NAME: " ${RELEASE_BRANCH_NAME}
-#
-#echo 'Releasing on enterprise'
-#
-#git clone https://github.com/dotCMS/core.git core
-#pushd core
-#echo 'Getting submodules'
-#git submodule update --init --recursive
-#git clean -f -d && git pull
-#
-#cd dotCMS/src/main/enterprise
-#git checkout ${RELEASE_BRANCH_NAME}
-#git commit --allow-empty -m "Publish Release"
-#git push origin ${RELEASE_BRANCH_NAME}
-#cd ../core
-#
-#echo 'Releasing on core-web'
-#git clone git@github.com:dotCMS/core-web.git core-web
-#pushd core-web
-#git clean -f -d && git pull
-#git checkout ${RELEASE_BRANCH_NAME}
-#git commit --allow-empty -m "Publish Release"
-#git push origin ${RELEASE_BRANCH_NAME}
-#cd ../core-web
-#
-#echo 'Releasing on plugin-seeds'
-#git clone git@github.com:dotCMS/plugin-seeds.git plugin-seeds
-#pushd plugin-seeds
-#git clean -f -d && git pull
-#git checkout ${RELEASE_BRANCH_NAME}
-#git commit --allow-empty -m "Publish Release"
-#git push origin ${RELEASE_BRANCH_NAME}
-#cd ../plugin-seeds
-#
-#echo 'Releasing on dot-cicd'
-#git clone git@github.com:dotCMS/dot-cicd.git dot-cicd
-#pushd dot-cicd
-#git clean -f -d && git pull
-#git checkout ${RELEASE_BRANCH_NAME}
-#git commit --allow-empty -m "Publish Release"
-#git push origin ${RELEASE_BRANCH_NAME}
-#cd ../dot-cicd
-#
-#echo 'Releasing on docker'
-#git clone git@github.com:dotCMS/docker.git docker-repo
-#pushd docker-repo
-#git clean -f -d && git pull
-#git checkout ${RELEASE_BRANCH_NAME}
-#git commit --allow-empty -m "Publish Release"
-#git push origin ${RELEASE_BRANCH_NAME}
-#cd ../docker-repo
+echo
+echo '######################################################################'
+echo "RELEASE_BRANCH_NAME: " ${RELEASE_BRANCH_NAME}
+
+echo 'Releasing on enterprise'
+
+git clone https://github.com/dotCMS/core.git core
+pushd core
+echo 'Getting submodules'
+git submodule update --init --recursive
+git clean -f -d && git pull
+
+cd dotCMS/src/main/enterprise
+git checkout ${RELEASE_BRANCH_NAME}
+git commit --allow-empty -m "Publish Release"
+git push origin ${RELEASE_BRANCH_NAME}
+cd ../core
+
+echo 'Releasing on core-web'
+git clone git@github.com:dotCMS/core-web.git core-web
+pushd core-web
+git clean -f -d && git pull
+git checkout ${RELEASE_BRANCH_NAME}
+git commit --allow-empty -m "Publish Release"
+git push origin ${RELEASE_BRANCH_NAME}
+cd ../core-web
+
+echo 'Releasing on plugin-seeds'
+git clone git@github.com:dotCMS/plugin-seeds.git plugin-seeds
+pushd plugin-seeds
+git clean -f -d && git pull
+git checkout ${RELEASE_BRANCH_NAME}
+git commit --allow-empty -m "Publish Release"
+git push origin ${RELEASE_BRANCH_NAME}
+cd ../plugin-seeds
+
+echo 'Releasing on dot-cicd'
+git clone git@github.com:dotCMS/dot-cicd.git dot-cicd
+pushd dot-cicd
+git clean -f -d && git pull
+git checkout ${RELEASE_BRANCH_NAME}
+git commit --allow-empty -m "Publish Release"
+git push origin ${RELEASE_BRANCH_NAME}
+cd ../dot-cicd
+
+echo 'Releasing on docker'
+git clone git@github.com:dotCMS/docker.git docker-repo
+pushd docker-repo
+git clean -f -d && git pull
+git checkout ${RELEASE_BRANCH_NAME}
+git commit --allow-empty -m "Publish Release"
+git push origin ${RELEASE_BRANCH_NAME}
+cd ../docker-repo

--- a/docker/release/build-src/publishGithubReleases.sh
+++ b/docker/release/build-src/publishGithubReleases.sh
@@ -13,23 +13,27 @@ RELEASE_BRANCH_NAME=${ee_build_id/v/$RELEASE_PREFIX}
 
 echo
 echo '######################################################################'
+echo "RELEASE_BRANCH_NAME: " ${RELEASE_BRANCH_NAME}
+
 echo 'Releasing on enterprise'
-echo "RELEASE_BRANCH_NAME: " + ${RELEASE_BRANCH_NAME}
-echo '######################################################################'
 
-git clone https://github.com/dotCMS/core.git core
-pushd core
-echo 'Getting submodules'
-git submodule update --init --recursive
+#git clone https://github.com/dotCMS/core.git core
+#pushd core
+#echo 'Getting submodules'
+#git submodule update --init --recursive
+#git clean -f -d && git pull
+#
+#cd dotCMS/src/main/enterprise
+#git checkout ${RELEASE_BRANCH_NAME}
+#git commit --allow-empty -m "Publish Release"
+#git push origin ${RELEASE_BRANCH_NAME}
+
+echo 'Releasing on core-web'
+git clone https://github.com/dotCMS/core-web.git core-web
+pushd core-web
 git clean -f -d && git pull
-
-cd dotCMS/src/main/enterprise
 git checkout ${RELEASE_BRANCH_NAME}
 git commit --allow-empty -m "Publish Release"
 git push origin ${RELEASE_BRANCH_NAME}
-
-#git checkout ${RELEASE_BRANCH_NAME}
-#git fetch --all
-#git commit --allow-empty -m "Publish Release"
 
 cd ../core

--- a/docker/release/build-src/publishGithubReleases.sh
+++ b/docker/release/build-src/publishGithubReleases.sh
@@ -29,7 +29,7 @@ echo 'Releasing on enterprise'
 #git push origin ${RELEASE_BRANCH_NAME}
 
 echo 'Releasing on core-web'
-git clone https://github.com/dotCMS/core-web.git core-web
+git clone git@github.com:dotCMS/core-web.git core-web
 pushd core-web
 git clean -f -d && git pull
 git checkout ${RELEASE_BRANCH_NAME}

--- a/docker/release/build-src/publishGithubReleases.sh
+++ b/docker/release/build-src/publishGithubReleases.sh
@@ -27,13 +27,27 @@ echo 'Releasing on enterprise'
 #git checkout ${RELEASE_BRANCH_NAME}
 #git commit --allow-empty -m "Publish Release"
 #git push origin ${RELEASE_BRANCH_NAME}
+#cd ../core
 
-echo 'Releasing on core-web'
-git clone git@github.com:dotCMS/core-web.git core-web
-pushd core-web
+#echo 'Releasing on core-web'
+#git clone git@github.com:dotCMS/core-web.git core-web
+#pushd core-web
+#git clean -f -d && git pull
+#git checkout ${RELEASE_BRANCH_NAME}
+#git commit --allow-empty -m "Publish Release"
+#git push origin ${RELEASE_BRANCH_NAME}
+#cd ../core-web
+
+echo 'Releasing on plugin-seeds'
+git clone git@github.com:dotCMS/plugin-seeds.git plugin-seeds
+pushd plugin-seeds
 git clean -f -d && git pull
 git checkout ${RELEASE_BRANCH_NAME}
 git commit --allow-empty -m "Publish Release"
 git push origin ${RELEASE_BRANCH_NAME}
+cd ../plugin-seeds
 
-cd ../core
+
+
+
+#cd ../core

--- a/docker/release/build-src/publishGithubReleases.sh
+++ b/docker/release/build-src/publishGithubReleases.sh
@@ -23,6 +23,11 @@ echo 'Getting submodules'
 git submodule update --init --recursive
 git clean -f -d && git pull
 
+cd core/src/main/enterprise
+git checkout ${RELEASE_BRANCH_NAME}
+git commit --allow-empty -m "Publish Release"
+git push origin ${RELEASE_BRANCH_NAME} 
+
 #git checkout ${RELEASE_BRANCH_NAME}
 #git fetch --all
 #git commit --allow-empty -m "Publish Release"

--- a/docker/release/build-src/publishGithubReleases.sh
+++ b/docker/release/build-src/publishGithubReleases.sh
@@ -23,7 +23,7 @@ echo 'Getting submodules'
 git submodule update --init --recursive
 git clean -f -d && git pull
 
-cd core/dotCMS/src/main/enterprise
+cd dotCMS/src/main/enterprise
 git checkout ${RELEASE_BRANCH_NAME}
 git commit --allow-empty -m "Publish Release"
 git push origin ${RELEASE_BRANCH_NAME}

--- a/docker/release/build-src/publishGithubReleases.sh
+++ b/docker/release/build-src/publishGithubReleases.sh
@@ -11,12 +11,12 @@ fi
 RELEASE_PREFIX="release-"
 RELEASE_BRANCH_NAME=${ee_build_id/v/$RELEASE_PREFIX}
 
-echo
-echo '######################################################################'
-echo "RELEASE_BRANCH_NAME: " ${RELEASE_BRANCH_NAME}
-
-echo 'Releasing on enterprise'
-
+#echo
+#echo '######################################################################'
+#echo "RELEASE_BRANCH_NAME: " ${RELEASE_BRANCH_NAME}
+#
+#echo 'Releasing on enterprise'
+#
 #git clone https://github.com/dotCMS/core.git core
 #pushd core
 #echo 'Getting submodules'
@@ -28,7 +28,7 @@ echo 'Releasing on enterprise'
 #git commit --allow-empty -m "Publish Release"
 #git push origin ${RELEASE_BRANCH_NAME}
 #cd ../core
-
+#
 #echo 'Releasing on core-web'
 #git clone git@github.com:dotCMS/core-web.git core-web
 #pushd core-web
@@ -37,30 +37,30 @@ echo 'Releasing on enterprise'
 #git commit --allow-empty -m "Publish Release"
 #git push origin ${RELEASE_BRANCH_NAME}
 #cd ../core-web
-
-echo 'Releasing on plugin-seeds'
-git clone git@github.com:dotCMS/plugin-seeds.git plugin-seeds
-pushd plugin-seeds
-git clean -f -d && git pull
-git checkout ${RELEASE_BRANCH_NAME}
-git commit --allow-empty -m "Publish Release"
-git push origin ${RELEASE_BRANCH_NAME}
-cd ../plugin-seeds
-
-echo 'Releasing on dot-cicd'
-git clone git@github.com:dotCMS/dot-cicd.git dot-cicd
-pushd dot-cicd
-git clean -f -d && git pull
-git checkout ${RELEASE_BRANCH_NAME}
-git commit --allow-empty -m "Publish Release"
-git push origin ${RELEASE_BRANCH_NAME}
-cd ../dot-cicd
-
-echo 'Releasing on docker'
-git clone git@github.com:dotCMS/docker.git docker-repo
-pushd docker-repo
-git clean -f -d && git pull
-git checkout ${RELEASE_BRANCH_NAME}
-git commit --allow-empty -m "Publish Release"
-git push origin ${RELEASE_BRANCH_NAME}
-cd ../docker-repo
+#
+#echo 'Releasing on plugin-seeds'
+#git clone git@github.com:dotCMS/plugin-seeds.git plugin-seeds
+#pushd plugin-seeds
+#git clean -f -d && git pull
+#git checkout ${RELEASE_BRANCH_NAME}
+#git commit --allow-empty -m "Publish Release"
+#git push origin ${RELEASE_BRANCH_NAME}
+#cd ../plugin-seeds
+#
+#echo 'Releasing on dot-cicd'
+#git clone git@github.com:dotCMS/dot-cicd.git dot-cicd
+#pushd dot-cicd
+#git clean -f -d && git pull
+#git checkout ${RELEASE_BRANCH_NAME}
+#git commit --allow-empty -m "Publish Release"
+#git push origin ${RELEASE_BRANCH_NAME}
+#cd ../dot-cicd
+#
+#echo 'Releasing on docker'
+#git clone git@github.com:dotCMS/docker.git docker-repo
+#pushd docker-repo
+#git clean -f -d && git pull
+#git checkout ${RELEASE_BRANCH_NAME}
+#git commit --allow-empty -m "Publish Release"
+#git push origin ${RELEASE_BRANCH_NAME}
+#cd ../docker-repo

--- a/docker/release/build-src/publishGithubReleases.sh
+++ b/docker/release/build-src/publishGithubReleases.sh
@@ -15,7 +15,7 @@ echo '######################################################################'
 
 mkdir -p ~/.ssh
 ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
-echo "${ee_rsa}" > ~/.ssh/id_rsa
+echo ${ee_rsa} > ~/.ssh/id_rsa
 chmod 600 ~/.ssh/id_rsa
 ls -las ~/.ssh
 git config --global user.email "dotcmsbuild@dotcms.com"

--- a/docker/release/build-src/publishGithubReleases.sh
+++ b/docker/release/build-src/publishGithubReleases.sh
@@ -8,9 +8,13 @@ if [[ ${is_release} != true ]]; then
   exit 1;
 fi
 
+RELEASE_PREFIX="release-"
+RELEASE_BRANCH_NAME=${ee_rsa/v/$RELEASE_PREFIX}
+
 echo
 echo '######################################################################'
 echo 'Releasing on enterprise'
+echo "RELEASE_BRANCH_NAME: " + ${RELEASE_BRANCH_NAME}
 echo '######################################################################'
 
 mkdir -p ~/.ssh
@@ -24,7 +28,7 @@ git config --global pull.rebase false
 
 git clone git@github.com:dotCMS/enterprise.git
 cd enterprise
-git checkout ${ee_build_id}
+git checkout ${RELEASE_BRANCH_NAME}
 git fetch --all
 git commit --allow-empty -m "Publish Release"
 

--- a/docker/release/build-src/updateOsgiVersion.sh
+++ b/docker/release/build-src/updateOsgiVersion.sh
@@ -82,7 +82,7 @@ if [[ ${is_release} != true ]]; then
   git checkout master
   git branch -D ${cicd_branch}
 else
-  git push origin ${release_branch_name}
+  git push ${github_plugin_seeds_token_repo} ${release_branch_name}
   git status
 fi
 

--- a/docker/release/build-src/updateOsgiVersion.sh
+++ b/docker/release/build-src/updateOsgiVersion.sh
@@ -86,4 +86,6 @@ else
   git status
 fi
 
+echo "Finish updating dotCMS version in OSGI plugins"
+
 cd ../core

--- a/docker/release/build-src/updateOsgiVersion.sh
+++ b/docker/release/build-src/updateOsgiVersion.sh
@@ -12,6 +12,8 @@ dotcms_current_version=$(curl https://api.github.com/repos/dotcms/core/releases/
 new_version="${dotcms_current_version//v}"
 echo "New version: ${new_version}"
 
+release_branch_name="release-"${new_version}
+
 if [[ -z "${new_version}" ]]; then
   echo "New version not provided"
   exit 1
@@ -21,8 +23,11 @@ cd ..
 git config --global user.email "${github_user_token}@dotcms.com"
 git config --global user.name "${github_user_token}"
 git clone ${github_plugin_seeds_repo}
+git remote set-url origin ${github_plugin_seeds_token_repo}
 cd plugin-seeds
 git fetch --all
+git checkout ${release_branch_name}
+git pull
 
 if [[ ${is_release} != true ]]; then
   cicd_branch='cicd-test'
@@ -78,7 +83,7 @@ if [[ ${is_release} != true ]]; then
   git checkout master
   git branch -D ${cicd_branch}
 else
-  git push ${github_plugin_seeds_token_repo}
+  git push origin ${plugin_seeds_repo}
   git status
 fi
 

--- a/docker/release/build-src/updateOsgiVersion.sh
+++ b/docker/release/build-src/updateOsgiVersion.sh
@@ -23,7 +23,6 @@ cd ..
 git config --global user.email "${github_user_token}@dotcms.com"
 git config --global user.name "${github_user_token}"
 git clone ${github_plugin_seeds_repo}
-git remote set-url origin ${github_plugin_seeds_token_repo}
 cd plugin-seeds
 git fetch --all
 git checkout ${release_branch_name}
@@ -83,7 +82,7 @@ if [[ ${is_release} != true ]]; then
   git checkout master
   git branch -D ${cicd_branch}
 else
-  git push origin ${plugin_seeds_repo}
+  git push origin ${release_branch_name}
   git status
 fi
 

--- a/pipeline/github/core/runRelease.sh
+++ b/pipeline/github/core/runRelease.sh
@@ -23,6 +23,7 @@ echo "Executing: docker run --rm \
   -e docker_password=${DOCKER_PASSWORD} \
   -e is_release=${IS_RELEASE} \
   -e debug=${DEBUG} \
+  -e ee_rsa=${SSH_RSA_KEY} \
  ${IMAGE_NAME} $2 $3 $4 $5 $6"
 echo '############################################################################################################################################'
 
@@ -47,6 +48,7 @@ docker run --rm \
   -e docker_password=${DOCKER_PASSWORD} \
   -e is_release=${IS_RELEASE} \
   -e debug=${DEBUG} \
+  -e ee_rsa=${SSH_RSA_KEY} \
   ${IMAGE_NAME} $2 $3 $4 $5 $6
 dResult=$?
 if [[ ${dResult} == 0 ]]; then

--- a/pipeline/github/core/runRelease.sh
+++ b/pipeline/github/core/runRelease.sh
@@ -48,7 +48,7 @@ docker run --rm \
   -e docker_password=${DOCKER_PASSWORD} \
   -e is_release=${IS_RELEASE} \
   -e debug=${DEBUG} \
-  -e ee_rsa=${SSH_RSA_KEY} \
+  -e ee_rsa="${SSH_RSA_KEY}" \
   ${IMAGE_NAME} $2 $3 $4 $5 $6
 dResult=$?
 if [[ ${dResult} == 0 ]]; then

--- a/pipeline/github/core/runRelease.sh
+++ b/pipeline/github/core/runRelease.sh
@@ -23,7 +23,7 @@ echo "Executing: docker run --rm \
   -e docker_password=${DOCKER_PASSWORD} \
   -e is_release=${IS_RELEASE} \
   -e debug=${DEBUG} \
-  -e ee_rsa=${SSH_RSA_KEY} \
+  -e ee_rsa=\"${SSH_RSA_KEY}\" \
  ${IMAGE_NAME} $2 $3 $4 $5 $6"
 echo '############################################################################################################################################'
 


### PR DESCRIPTION
Adding an additional step to publish GitHub releases on our different repos as part of the automated release process. 
Repos: 
* ee
* core-web 
* plugin-seeds
* dot-cicd
* docker

The trigger of releasing on GitHub is a commit with the message "Publish Release" on each repo. This is processed by a GitHub workflow that handles the publishing of the release on each repo. 