### PR TITLE
(#20246): Adding fallback to docker repo when core's Dockerfile is missing

### DIFF
--- a/docker/images/release/build-src/getSource.sh
+++ b/docker/images/release/build-src/getSource.sh
@@ -4,30 +4,20 @@
 # Script: getSource.sh
 # Git clones core repo with submodules (enterprise) with provided branch
 #
-# $1: github_user: github user to run clone on behalf of
+# $1: GITHUB_USER: github user to run clone on behalf of
 # $2: github_user_token: token associated to user
 # $3: build_id: branch or commit
 
-github_user=${1}
+export GITHUB_USER=${1}
 github_user_token=${2}
 build_id=${3}
 
 cd /build/src
 # Clone with submodules
-gitCloneSubModules $(resolveRepoUrl ${CORE_GITHUB_REPO} ${github_user_token} ${github_user}) ${build_id}
+gitCloneSubModules $(resolveRepoUrl ${CORE_GITHUB_REPO} ${github_user_token} ${GITHUB_USER}) ${build_id}
 
 pushd ${CORE_GITHUB_REPO}
 echo 'Git status:'
 git branch
 git status
-
-# Switch to enterprise and make sure the branch id exist and pull from it
-pushd dotCMS/src/main/enterprise
-git checkout -b ${build_id} --track origin/${build_id}
-git pull origin ${build_id}
-echo 'Git status:'
-git branch
-git status
-popd
-
 popd

--- a/docker/images/release/build-src/publishGithubReleases.sh
+++ b/docker/images/release/build-src/publishGithubReleases.sh
@@ -36,7 +36,7 @@ function commitAndPush {
 # $2: module_path: when present it represents the path where submodule is targeted
 function pushRelease {
   local repo=${1}
-  local module_path=${2}
+  local with_submodules=${2}
   local repo_url=$(resolveRepoUrl ${repo} ${github_user_token} ${github_user})
 
   # Verifies for branch to be remote, if it does not exist ignore this repo
@@ -51,15 +51,12 @@ Releasing on ${repo}
 #############################"
   # Git clones the repo and depending on module_path it clones the submodules as well
   if [[ -n "${module_path}" ]]; then
-    gitCloneSubModules ${repo_url} ${RELEASE_BRANCH_NAME} ${repo}
-    pushd ${module_path}
-    git checkout -b ${RELEASE_BRANCH_NAME} --track origin/${RELEASE_BRANCH_NAME}
-    git pull origin ${RELEASE_BRANCH_NAME}
+    gitCloneSubModules ${repo_url} ${RELEASE_BRANCH_NAME} ${repo} ${github_user}
   else
     gitClone ${repo_url} ${RELEASE_BRANCH_NAME} ${repo}
-    pushd ${repo}
   fi
 
+  pushd ${repo}
   # Commit and pushes "changes"
   commitAndPush ${repo_url}
   popd

--- a/docker/images/release/build-src/updateOsgiVersion.sh
+++ b/docker/images/release/build-src/updateOsgiVersion.sh
@@ -17,7 +17,7 @@ dotcms_current_version=$(curl https://api.github.com/repos/dotcms/core/releases/
 new_version="${dotcms_current_version//v}"
 echo "New version: ${new_version}"
 
-release_branch_name="release-"${new_version}
+release_branch_name="release-${new_version}"
 
 if [[ -z "${new_version}" ]]; then
   echo "New version not provided"
@@ -29,7 +29,7 @@ pushd ../
 gitConfig ${github_user}
 plugin_seeds_github_repo_url=$(resolveRepoUrl ${PLUGIN_SEEDS_GITHUB_REPO} ${github_user_token} ${github_user})
 # Clones plugin_seeds repo
-gitClone ${plugin_seeds_github_repo_url} ${release_branch_name}
+gitClone ${plugin_seeds_github_repo_url}
 pushd ${PLUGIN_SEEDS_GITHUB_REPO}
 
 if [[ "${is_release}" != 'true' ]]; then

--- a/local/core/runCurl.sh
+++ b/local/core/runCurl.sh
@@ -53,13 +53,17 @@ WAIT_DOTCMS_FOR: ${WAIT_DOTCMS_FOR}
 DEBUG_MODE: ${DEBUG_MODE}
 "
 
-fetchDocker ${DOT_CICD_DOCKER_PATH} ${DOCKER_BRANCH}
+# Resolve which docker path to use (core or docker repo folder)
+RESOLVED_DOCKER_PATH=$(dockerPathWithFallback ${DOT_CICD_TARGET}/dotcms ${DOT_CICD_DOCKER_PATH})
+# Git clones docker repo with provided branch if
+[[ "${RESOLVED_DOCKER_PATH}" == "${DOT_CICD_DOCKER_PATH}" ]] \
+  && fetchDocker ${DOT_CICD_DOCKER_PATH} ${DOCKER_BRANCH}
 
 if [[ "${SKIP_IMAGE_BUILD}" == 'false' ]]; then
   buildBase cicd-dotcms ${DOCKER_DOTCMS_PATH}
 fi
 
-setupDocker ${DOT_CICD_STAGE_OPERATION} ${DOT_CICD_DOCKER_PATH}
+setupDocker ${DOT_CICD_STAGE_OPERATION} ${RESOLVED_DOCKER_PATH}
 cp ${DOCKER_SOURCE}/tests/shared/* ${DOT_CICD_STAGE_OPERATION}
 cp ${DOCKER_SOURCE}/tests/curl/* ${DOT_CICD_STAGE_OPERATION}
 buildBase ${IMAGE_NAME} ${DOT_CICD_STAGE_OPERATION} true

--- a/pipeline/github/core/publishDockerImage.sh
+++ b/pipeline/github/core/publishDockerImage.sh
@@ -22,8 +22,16 @@ cd ..
 # Configs git with default user
 gitConfig ${GITHUB_USER}
 # Git clones docker repo with provided branch
-fetchDocker docker ${DOCKER_BRANCH}
-cd docker/images/dotcms
+core_docker_path=/build/src/core/docker
+# Resolve which docker path to use (core or docker repo folder)
+resolved_docker_path=$(dockerPathWithFallback ${core_docker_path} docker)
+# Git clones docker repo with provided branch if
+if [[ "${resolved_docker_path}" == 'docker' ]]; then
+  fetchDocker docker ${DOCKER_BRANCH}
+  pushd docker/images/dotcms
+else
+  pushd ${core_docker_path}
+fi
 
 if [[ "${IS_RELEASE}" != 'true' ]]; then
   docker_image_name="${docker_image_name}-cicd-test"

--- a/pipeline/github/core/runCurl.sh
+++ b/pipeline/github/core/runCurl.sh
@@ -17,12 +17,15 @@ docker_dotcms_path=${docker_repo_path}/images/dotcms
 docker_file_path="${DOCKER_SOURCE}/tests/curl"
 shared_folder=${DOCKER_SOURCE}/tests/shared
 
-# Git clones docker repo with provided branch
-fetchDocker ${docker_repo_path} ${DOCKER_BRANCH}
+# Resolve which docker path to use (core or docker repo folder)
+resolved_docker_path=$(dockerPathWithFallback ${DOT_CICD_TARGET}/dotcms ${docker_repo_path})
+# Git clones docker repo with provided branch when docker repo matches docker path
+[[ "${resolved_docker_path}" == "${docker_repo_path}" ]] \
+  && fetchDocker ${docker_repo_path} ${DOCKER_BRANCH}
 # Builds parametrized dotcms image for it to be extended later
 buildBase cicd-dotcms ${docker_dotcms_path}
 # Copies folders with database volume and scripts to be included in the image
-setupDocker ${docker_file_path} ${docker_repo_path}
+setupDocker ${docker_file_path} ${resolved_docker_path}
 # Builds curl-tests image from parametrized image
 buildBase ${IMAGE_NAME} ${docker_file_path} true
 # Adds license file to volume

--- a/pipeline/github/core/runRelease.sh
+++ b/pipeline/github/core/runRelease.sh
@@ -13,12 +13,12 @@ cp ${DOT_CICD_LIB}/pipeline/github/githubCommon.sh ${DOCKER_SOURCE}/images/relea
 pushd ${DOCKER_SOURCE}/images/release
 
 # When is not a release, build the release-process docker image
-#if [[ "${IS_RELEASE}" != 'true' ]]; then
-#  executeCmd "docker build --pull --no-cache -t ${IMAGE_NAME} ."
-#  if [[ ${cmdResult} != 0 ]]; then
-#    exit 1
-#  fi
-#fi
+if [[ "${IS_RELEASE}" != 'true' ]]; then
+  executeCmd "docker build --pull --no-cache -t ${IMAGE_NAME} ."
+  if [[ ${cmdResult} != 0 ]]; then
+    exit 1
+  fi
+fi
 
 if [[ -n "${BASE_FOLDER}" ]]; then
   HOME_FOLDER=${BASE_FOLDER}
@@ -27,28 +27,27 @@ fi
 # Removes first argument
 set -- ${@:2}
 # Start docker release-process container
-#executeCmd "docker run --rm
-#  -v ${HOME_FOLDER}/.ssh:/root/.ssh
-#  -e BUILD_ID=\"${BUILD_ID}\"
-#  -e BUILD_HASH=${BUILD_HASH}
-#  -e EE_BUILD_ID=\"${EE_BRANCH}\"
-#  -e repo_username=${REPO_USERNAME}
-#  -e repo_password=${REPO_PASSWORD}
-#  -e GITHUB_USER=${GITHUB_USER}
-#  -e GITHUB_USER_EMAIL:=${GITHUGITHUB_USER_EMAIL:B_USER}
-#  -e GITHUB_USER_TOKEN=${GITHUB_USER_TOKEN}
-#  -e aws_access_key_id=${AWS_ACCESS_KEY_ID}
-#  -e aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
-#  -e docker_username=${DOCKER_USERNAME}
-#  -e docker_password=${DOCKER_PASSWORD}
-#  -e is_release=${IS_RELEASE}
-#  -e DEBUG=${DEBUG}
-#  ${IMAGE_NAME} $@"
-#
-#popd
-#
-#if [[ ${cmdResult} == 0 ]]; then
-#  exit 0
-#else
-#  exit 1
-#fi
+executeCmd "docker run --rm
+  -e BUILD_ID=\"${BUILD_ID}\"
+  -e BUILD_HASH=${BUILD_HASH}
+  -e EE_BUILD_ID=\"${EE_BRANCH}\"
+  -e repo_username=${REPO_USERNAME}
+  -e repo_password=${REPO_PASSWORD}
+  -e GITHUB_USER=${GITHUB_USER}
+  -e GITHUB_USER_EMAIL:=${GITHUGITHUB_USER_EMAIL:B_USER}
+  -e GITHUB_USER_TOKEN=${GITHUB_USER_TOKEN}
+  -e aws_access_key_id=${AWS_ACCESS_KEY_ID}
+  -e aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
+  -e docker_username=${DOCKER_USERNAME}
+  -e docker_password=${DOCKER_PASSWORD}
+  -e is_release=${IS_RELEASE}
+  -e DEBUG=${DEBUG}
+  ${IMAGE_NAME} $@"
+
+popd
+
+if [[ ${cmdResult} == 0 ]]; then
+  exit 0
+else
+  exit 1
+fi

--- a/pipeline/github/core/runSidecar.sh
+++ b/pipeline/github/core/runSidecar.sh
@@ -68,8 +68,12 @@ fi
 # Login to docker
 echo ${DOCKER_TOKEN} | docker login --username ${DOCKER_USERNAME} --password-stdin
 
-# Git clones docker repo
-fetchDocker ${docker_repo_path} ${DOCKER_BRANCH}
+# Resolve which docker path to use (core or docker repo folder)
+resolved_docker_path=$(dockerPathWithFallback ${DOT_CICD_TARGET}/dotcms ${docker_repo_path})
+# Git clones docker repo with provided branch when docker repo matches docker path
+[[ "${resolved_docker_path}" == "${docker_repo_path}" ]] \
+  && fetchDocker ${docker_repo_path} ${DOCKER_BRANCH}
+
 # Builds parametrized dotcms image for it to be used later
 buildBase cicd-dotcms ${docker_dotcms_path}
 # Copies folders with database volume and scripts to be included in the image

--- a/pipeline/github/ee/getSource.sh
+++ b/pipeline/github/ee/getSource.sh
@@ -3,14 +3,14 @@
 ######################
 # Script: getSource.sh
 # Git clones core repo with its submodules using github credentials (user and token) and the provided branch
+#
+# $1: GITHUB_USER: github user to run clone on behalf of
+# $2: github_user_token: token associated to user
+# $3: build_id: branch or commit
 
-github_user=${1}
+export GITHUB_USER=${1}
 github_user_token=${2}
 build_id=${3}
 
 pushd ${DOT_CICD_PATH}
-gitCloneSubModules $(resolveRepoUrl ${CORE_GITHUB_REPO} ${github_user_token} ${github_user}) ${build_id}
-pushd ${CORE_GITHUB_REPO}/dotCMS/src/main/enterprise
-git checkout -b ${build_id} --track origin/${build_id}
-git pull origin ${build_id}
-popd
+gitCloneSubModules $(resolveRepoUrl ${CORE_GITHUB_REPO} ${github_user_token} ${GITHUB_USER}) ${build_id}


### PR DESCRIPTION
Introducing the functionality to look for DotCMS Docker images from the `core` repo. Keeping a copy in `docker` repo as a fallback option when for any reason it cannot find it.