### PR TITLE
fix coreWeb pump versioning not upgrading year on EOY

### DIFF
--- a/docker/images/prerelease/build-src/preReleaseCommon.sh
+++ b/docker/images/prerelease/build-src/preReleaseCommon.sh
@@ -137,9 +137,16 @@ function getValidNpmVersion {
 # $1: version
 function pumpUpVersion {
   local arr_in=(${1//./ })
+  local year=$arr_in
   local month=$((arr_in[1] + 1))
-  [[ $month -gt 12 ]] && month=1
-  echo ${arr_in[0]}.${month}.$((arr_in[2]))
+
+  if [ $month -gt 12 ]
+    then
+      month=1
+      year=$((year+1))
+    fi
+
+  echo ${year}.${month}.$((arr_in[2]))
 }
 
 # Runs a 'npm publish -tag' command with a provided tag


### PR DESCRIPTION
when the versioning gets to End of year and the pump version is done, the `year` stays the same and not upgrade, only the month